### PR TITLE
Correct Ctrl-K behavior

### DIFF
--- a/Commands/Text/DeleteToEndOfLineCommand.cs
+++ b/Commands/Text/DeleteToEndOfLineCommand.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.Editor.EmacsEmulation.Commands
         internal override void Execute(EmacsCommandContext context)
         {
             // we can't use the repeating support because of the special behavior of UniversalArgument=0
-            if (context.Manager.UniversalArgument == 0)
+            if (!context.UniversalArgument.HasValue || context.Manager.UniversalArgument == 0)
             {
                 ITextCaret caret = context.TextView.Caret;
                 int caretPosition = caret.Position.BufferPosition.Position;
@@ -61,14 +61,9 @@ namespace Microsoft.VisualStudio.Editor.EmacsEmulation.Commands
                     }
                 }
             }
-            else if (!context.UniversalArgument.HasValue || context.UniversalArgument > 0)
+            else // (context.UniversalArgument > 0)
             {
-                int count = context.Manager.GetUniversalArgumentOrDefault(1);
-                if (count == 1)
-                {
-                    context.EditorOperations.DeleteToEndOfPhysicalLine();
-                }
-                else while (count-- > 0)
+                for (int count = context.Manager.GetUniversalArgumentOrDefault(1); count > 0; count--)
                 {
                     int caretPosition = context.TextView.Caret.Position.BufferPosition.Position;
                     int nextLineStart = context.TextView.Caret.ContainingTextViewLine.EndIncludingLineBreak.Position;

--- a/Commands/Text/DeleteToEndOfLineCommand.cs
+++ b/Commands/Text/DeleteToEndOfLineCommand.cs
@@ -57,6 +57,7 @@ namespace Microsoft.VisualStudio.Editor.EmacsEmulation.Commands
                         {
                             // reached end of line and every character was a whitespace
                             context.EditorOperations.Delete(caretPosition, startOfNextLine - caretPosition);
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Just started using this addon in VS2015 and was seeing wrong behavior in Ctrl-K.

It was killing the line contents to right or caret, but not killing line break if only whitespace remained to right of caret.

Fix for #10 
